### PR TITLE
Remove main heading from triangular estimation page

### DIFF
--- a/triangular-estimation.html
+++ b/triangular-estimation.html
@@ -11,7 +11,6 @@
     <title>Оценка по трем точкам</title>
 </head>
 <body>
-    <h1>Оценка по трем точкам</h1>
     <div class="main-container wider">
         <a href="https://github.com/Thisman/thisman.github.io" class="github-link" target="_blank">
             <img src="./images/github-icon.png" />


### PR DESCRIPTION
## Summary
- remove the redundant `<h1>` tag from `triangular-estimation.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855fa64fb0c832fb00172c2e5d45ad3