### PR TITLE
Enhance triangular estimation graph

### DIFF
--- a/triangular-estimation.js
+++ b/triangular-estimation.js
@@ -10,10 +10,10 @@ function triangularPdf(x, a, c, b) {
     return (2 * (b - x)) / ((b - a) * (b - c));
 }
 
-function drawGraph(o, r, p) {
+function drawGraph(o, r, p, estimate) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    const margin = 30;
-    const maxX = Math.max(o, r, p) + 2;
+    const margin = 40;
+    const maxX = Math.max(o, r, p, estimate) + 2;
     const scaleX = (canvas.width - margin * 2) / maxX;
     const maxY = triangularPdf(r, o, r, p);
     const scaleY = (canvas.height - margin * 2) / maxY;
@@ -25,6 +25,44 @@ function drawGraph(o, r, p) {
     ctx.moveTo(margin, canvas.height - margin);
     ctx.lineTo(margin, margin);
     ctx.stroke();
+
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    for (let i = 0; i <= maxX; i++) {
+        const x = margin + i * scaleX;
+        ctx.beginPath();
+        ctx.moveTo(x, canvas.height - margin);
+        ctx.lineTo(x, canvas.height - margin + 5);
+        ctx.stroke();
+        ctx.fillText(i, x, canvas.height - margin + 7);
+    }
+
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (let i = 0; i <= 5; i++) {
+        const yVal = (maxY / 5) * i;
+        const y = canvas.height - margin - yVal * scaleY;
+        ctx.beginPath();
+        ctx.moveTo(margin - 5, y);
+        ctx.lineTo(margin, y);
+        ctx.stroke();
+        ctx.fillText(yVal.toFixed(2), margin - 7, y);
+    }
+
+    ctx.save();
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText('X', canvas.width - margin, canvas.height - margin + 20);
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(margin - 25, margin);
+    ctx.rotate(-Math.PI / 2);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText('Y', 0, 0);
+    ctx.restore();
 
     ctx.beginPath();
     for (let i = 0; i <= 100; i++) {
@@ -42,10 +80,20 @@ function drawGraph(o, r, p) {
         const x = margin + val * scaleX;
         const y = canvas.height - margin - yVal * scaleY;
         ctx.fillStyle = colors[i];
+        ctx.globalAlpha = 0.5;
         ctx.beginPath();
         ctx.arc(x, y, 5, 0, Math.PI * 2);
         ctx.fill();
     });
+
+    const yVal = triangularPdf(estimate, o, r, p);
+    const x = margin + estimate * scaleX;
+    const y = canvas.height - margin - yVal * scaleY;
+    ctx.fillStyle = '#000';
+    ctx.globalAlpha = 1;
+    ctx.beginPath();
+    ctx.arc(x, y, 5, 0, Math.PI * 2);
+    ctx.fill();
 }
 
 button.addEventListener('click', () => {
@@ -56,7 +104,7 @@ button.addEventListener('click', () => {
         resultEl.textContent = 'Введите все оценки';
         return;
     }
-    drawGraph(o, r, p);
-    const estimate = (o + 4 * r + p) / 6;
-    resultEl.textContent = 'Итоговая оценка: ' + estimate.toFixed(2);
+    const estimate = Math.ceil((o + 4 * r + p) / 6);
+    drawGraph(o, r, p, estimate);
+    resultEl.textContent = 'Итоговая оценка: ' + estimate;
 });


### PR DESCRIPTION
## Summary
- add axis labels and scale marks to the triangular estimation chart
- display input points semi-transparent and result point opaque
- round final result up and plot it on the graph

## Testing
- `node --check triangular-estimation.js`


------
https://chatgpt.com/codex/tasks/task_e_6855fc51603c832f8fa2953de9876213