### PR TITLE
Use Chart.js for triangular estimation graph

### DIFF
--- a/triangular-estimation.html
+++ b/triangular-estimation.html
@@ -43,6 +43,7 @@
         </div>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="triangular-estimation.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Chart.js via CDN
- rewrite triangular estimation script to render the graph using Chart.js

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6855ffc31260832f9a2ea373636c7c37