### PR TITLE
Improve triangular estimation validation

### DIFF
--- a/triangular-estimation.html
+++ b/triangular-estimation.html
@@ -39,9 +39,9 @@
         </div>
         <div class="graph">
             <canvas id="chart" width="400" height="300"></canvas>
-            <div id="result" class="result">Итоговая оценка: -</div>
         </div>
         </div>
+        <div id="result" class="result">Итоговая оценка: -</div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="triangular-estimation.js"></script>

--- a/triangular-estimation.js
+++ b/triangular-estimation.js
@@ -99,13 +99,18 @@ button.addEventListener('click', () => {
         clearGraphWithError();
         return;
     }
-    if (r <= o) {
-        resultEl.textContent = 'Реалистичная оценка должна быть больше оптимистичной';
+    if (o > r || o > p) {
+        resultEl.textContent = 'Оптимистичная оценка не должна быть больше других оценок';
         clearGraphWithError();
         return;
     }
-    if (p <= r) {
-        resultEl.textContent = 'Пессимистичная оценка должна быть больше реалистичной';
+    if (r < o || r > p) {
+        resultEl.textContent = 'Реалистичная оценка должна быть не меньше оптимистичной и не больше пессимистичной';
+        clearGraphWithError();
+        return;
+    }
+    if (p < r || p < o) {
+        resultEl.textContent = 'Пессимистичная оценка должна быть не меньше остальных оценок';
         clearGraphWithError();
         return;
     }


### PR DESCRIPTION
## Summary
- refine validation for the triangular estimation tool
- move result block below the content to span the full width

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68569940f518832fb5d9ed9b2816e4a8