### PR TITLE
Remove main title and center navigation buttons

### DIFF
--- a/index.css
+++ b/index.css
@@ -15,21 +15,13 @@ body {
     position: relative;
     width: 700px;
     margin: auto;
-    padding: 32px 8px 16px;
+    padding: 32px 8px;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     min-height: 100vh;
-}
-
-.main-title {
-    font-size: 36px;
-    font-weight: 700;
-    margin-bottom: 48px;
-    text-align: center;
-    color: var(--text-primary);
 }
 
 .buttons-container {
@@ -77,12 +69,7 @@ body {
         width: 100%;
         padding: 16px;
     }
-    
-    .main-title {
-        font-size: 28px;
-        margin-bottom: 32px;
-    }
-    
+
     .buttons-container {
         max-width: 100%;
     }

--- a/index.html
+++ b/index.html
@@ -72,8 +72,6 @@
             <img src="./images/github-icon.png" alt="GitHub репозиторий" />
         </a>
         
-        <h1 class="main-title">Главная по подсчетам</h1>
-        
         <div class="buttons-container">
             <a href="./how-many-sp/index.html" class="btn nav-button" title="Калькулятор сторипоинтов">
                 Сколько сториков?


### PR DESCRIPTION
## Summary
- Drop the "Главная по подсчетам" heading from the main page so only navigation buttons remain
- Adjust landing page styles to center navigation vertically and remove unused title styles

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b737ec292c832fa3c3722c6e19d79f