### PR TITLE
Add shared footer with GitHub and home links

### DIFF
--- a/gamma-trainer/index.html
+++ b/gamma-trainer/index.html
@@ -8,17 +8,9 @@
 <link rel="stylesheet" href="./index.css">
 </head>
 <body>
-  <div class="main-container">
-    <a href="/index.html" class="main-link" title="На главную">
-        <img src="/images/main-icon.png" alt="Перейти на главную страницу" />
-    </a>
-    <a href="https://github.com/Thisman/thisman.github.io" class="github-link" target="_blank">
-        <img src="/images/github-icon.png" alt="GitHub репозиторий" />
-    </a>
-  </div>
-  <div class="container">
-    <div class="toolbar">
-      <div aria-label="Выбор тоники" role="radiogroup" class="chipbar nowrap" id="tonicBar"></div>
+    <div class="container">
+      <div class="toolbar">
+        <div aria-label="Выбор тоники" role="radiogroup" class="chipbar nowrap" id="tonicBar"></div>
       <div aria-label="Выбор лада" role="radiogroup" class="chipbar wrap" id="modeBar"></div>
     </div>
 
@@ -41,9 +33,13 @@
           </div>
         </div>
       </aside>
+      </div>
     </div>
-  </div>
+    <footer class="footer">
+      <a href="/index.html">Главная</a>
+      <a href="https://github.com/Thisman/thisman.github.io" target="_blank">GitHub</a>
+    </footer>
 
-<script src="./index.js"></script>
-</body>
-</html>
+  <script src="./index.js"></script>
+  </body>
+  </html>

--- a/how-many-sp/index.html
+++ b/how-many-sp/index.html
@@ -76,12 +76,6 @@
 </head>
 <body>
     <div class="main-container">
-        <a href="/index.html" class="main-link" title="На главную">
-            <img src="/images/main-icon.png" alt="Перейти на главную страницу" />
-        </a>
-        <a href="https://github.com/Thisman/thisman.github.io" class="github-link" target="_blank">
-            <img src="/images/github-icon.png" alt="GitHub репозиторий" />
-        </a>
         <div class="description">
             <h4>Сайт позволяет посчитать количество сторипоинтов для оценки задачи.</h4>
             Оценка строится из трех шагов:
@@ -152,6 +146,10 @@
         </div>
         <div class="sp-count-description" id="sp-description"></div>
     </div>
+    <footer class="footer">
+        <a href="/index.html">Главная</a>
+        <a href="https://github.com/Thisman/thisman.github.io" target="_blank">GitHub</a>
+    </footer>
     <script type="module" src="./index.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -68,10 +68,6 @@
 </head>
 <body>
     <div class="main-container">
-        <a href="https://github.com/Thisman/thisman.github.io" class="github-link" target="_blank">
-            <img src="./images/github-icon.png" alt="GitHub репозиторий" />
-        </a>
-        
         <div class="buttons-container">
             <a href="./how-many-sp/index.html" class="btn nav-button" title="Калькулятор сторипоинтов">
                 Сколько сториков?
@@ -84,5 +80,8 @@
             </a>
         </div>
     </div>
+    <footer class="footer">
+        <a href="https://github.com/Thisman/thisman.github.io" target="_blank">GitHub</a>
+    </footer>
 </body>
 </html>

--- a/styles/common.css
+++ b/styles/common.css
@@ -13,6 +13,10 @@
     --text-muted: #ddd;
     --border-color: #ddd;
     --background-light: #ffdddd;
+
+    /* Footer */
+    --footer-bg: #000;
+    --footer-height: 40px;
     
     /* Typography */
     --font-primary: 'Roboto Condensed', sans-serif;
@@ -45,7 +49,7 @@ body {
     width: 100%;
     height: 100%;
     margin: 0;
-    padding: 0;
+    padding: 0 0 var(--footer-height) 0;
     font-family: var(--font-primary);
     line-height: 1.5;
 }
@@ -231,4 +235,23 @@ h1, h2, h3, h4, h5, h6 {
     .result {
         font-size: 60px;
     }
-} 
+}
+
+/* Footer */
+.footer {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: var(--footer-height);
+    background: var(--footer-bg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: var(--spacing-md);
+}
+
+.footer a {
+    color: #fff;
+    text-decoration: none;
+}

--- a/triangular-estimation/index.html
+++ b/triangular-estimation/index.html
@@ -78,12 +78,6 @@
 </head>
 <body>
     <div class="main-container">
-        <a href="/index.html" class="main-link" title="На главную">
-            <img src="/images/main-icon.png" alt="Перейти на главную страницу" />
-        </a>
-        <a href="https://github.com/Thisman/thisman.github.io" class="github-link" target="_blank">
-            <img src="/images/github-icon.png" alt="GitHub репозиторий" />
-        </a>
         <div class="description">
             <h4>Оценка по трём точкам</h4>
             Метод позволяет учесть оптимистичную, реалистичную и пессимистичную оценку задачи.
@@ -135,6 +129,10 @@
             <canvas id="chart" width="700" height="300"></canvas>
         </div>
     </div>
+    <footer class="footer">
+        <a href="/index.html">Главная</a>
+        <a href="https://github.com/Thisman/thisman.github.io" target="_blank">GitHub</a>
+    </footer>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="./index.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Introduce a common footer with centered dark theme links across site pages
- Centralize footer styling in `styles/common.css`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7396a62ec832f872358ebb94853ac