### PR TITLE
Fix constant width for gamma trainer notes

### DIFF
--- a/gamma-trainer/index.css
+++ b/gamma-trainer/index.css
@@ -176,6 +176,11 @@ body {
 }
 
 .note {
+    width: 78px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 10px 14px;
     border-radius: 999px;
     background: var(--pill-bg);


### PR DESCRIPTION
## Summary
- fix note width to 78px and center content to avoid layout jumps

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b73bc976e0832fb9a6f416f280e5d8